### PR TITLE
Quick fix for not detecting F/A-18C unit.

### DIFF
--- a/DCSLM/UnitManager.py
+++ b/DCSLM/UnitManager.py
@@ -116,6 +116,8 @@ class UnitManager:
 
   def get_unit_from_dcsuf_text(self, dcsufText):
     if dcsufText:
+      if(dcsufText == "F/A-18C"):
+        dcsufText = "F/A-18C Hornet"
       for c in self.Categories:
         if c in self.Units.keys():
           for u,d in self.Units[c].items():


### PR DESCRIPTION
This is a very dirty fix for a very specific purpose, I think the name matching itself should be overhauled, but I am using this since a lot of liveries do not contain the "Hornet" tag.